### PR TITLE
Feature/perf improvements for table

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           # What benchmark tool the output.txt came from
           tool: 'benchmarkdotnet'
+          save-data-file: github.event_name != 'pull_request'
           # Where the output from the benchmark tool is stored
           output-file-path: Benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.Benchmarks-report-full-compressed.json
           # Where the previous data file is stored

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           # What benchmark tool the output.txt came from
           tool: 'benchmarkdotnet'
-          save-data-file: github.event_name != 'pull_request'
+          save-data-file: ${{ github.event_name != 'pull_request' }}
           # Where the output from the benchmark tool is stored
           output-file-path: Benchmark/BenchmarkDotNet.Artifacts/results/Benchmark.Benchmarks-report-full-compressed.json
           # Where the previous data file is stored

--- a/Benchmark/Benchmarks.cs
+++ b/Benchmark/Benchmarks.cs
@@ -16,22 +16,22 @@ namespace Benchmark
         public IEnumerable<AImplementation> Impls()
         {
             // crashing for now
-            yield return new NeoImplementation();
-            yield return new KeraImplementation();
-            yield return new MoonSharpImplementation();
-            yield return new NLuaImplementation();
+            //yield return new NeoImplementation();
+            //yield return new KeraImplementation();
+            //yield return new MoonSharpImplementation();
+            //yield return new NLuaImplementation();
             yield return new SolarSharpImplementation();
         }
 
         public IEnumerable<LuaFile> Tests()
         {
-            yield return new LuaFile("./Tests/empty_test.lua");
-            yield return new LuaFile("./Tests/binarytrees.lua-2.lua");
-            yield return new LuaFile("./Tests/ack.lua");
             yield return new LuaFile("./Tests/queen.lua");
-            yield return new LuaFile("./Tests/sieve.lua");
             yield return new LuaFile("./Tests/mandel.lua");
-            yield return new LuaFile("./Tests/heapsort.lua");
+            //yield return new LuaFile("./Tests/empty_test.lua");
+            //yield return new LuaFile("./Tests/binarytrees.lua-2.lua");
+            //yield return new LuaFile("./Tests/ack.lua");
+            //yield return new LuaFile("./Tests/sieve.lua");
+            //yield return new LuaFile("./Tests/heapsort.lua");
             //yield return new LuaFile("./Tests/regexredux.lua-2.lua");
 
             //foreach (var file in Directory.GetFiles("./Tests", "*.lua", SearchOption.AllDirectories))

--- a/Benchmark/Benchmarks.cs
+++ b/Benchmark/Benchmarks.cs
@@ -45,7 +45,7 @@ namespace Benchmark
         {
             var t = Task.Run(() => Implementation.Run(Test.Contents));
             // limiting execution to 2 mins
-            var winner = await Task.WhenAny(t, Task.Delay(TimeSpan.FromSeconds(10)));
+            var winner = await Task.WhenAny(t, Task.Delay(TimeSpan.FromSeconds(20)));
             if (winner == t)
             {
                 // success

--- a/Benchmark/Benchmarks.cs
+++ b/Benchmark/Benchmarks.cs
@@ -15,11 +15,10 @@ namespace Benchmark
 
         public IEnumerable<AImplementation> Impls()
         {
-            // crashing for now
-            //yield return new NeoImplementation();
-            //yield return new KeraImplementation();
-            //yield return new MoonSharpImplementation();
-            //yield return new NLuaImplementation();
+            yield return new NeoImplementation();
+            yield return new KeraImplementation();
+            yield return new MoonSharpImplementation();
+            yield return new NLuaImplementation();
             yield return new SolarSharpImplementation();
         }
 
@@ -27,12 +26,12 @@ namespace Benchmark
         {
             yield return new LuaFile("./Tests/queen.lua");
             yield return new LuaFile("./Tests/mandel.lua");
-            //yield return new LuaFile("./Tests/empty_test.lua");
-            //yield return new LuaFile("./Tests/binarytrees.lua-2.lua");
-            //yield return new LuaFile("./Tests/ack.lua");
-            //yield return new LuaFile("./Tests/sieve.lua");
-            //yield return new LuaFile("./Tests/heapsort.lua");
-            //yield return new LuaFile("./Tests/regexredux.lua-2.lua");
+            yield return new LuaFile("./Tests/empty_test.lua");
+            yield return new LuaFile("./Tests/binarytrees.lua-2.lua");
+            yield return new LuaFile("./Tests/ack.lua");
+            yield return new LuaFile("./Tests/sieve.lua");
+            yield return new LuaFile("./Tests/heapsort.lua");
+            yield return new LuaFile("./Tests/regexredux.lua-2.lua");
 
             //foreach (var file in Directory.GetFiles("./Tests", "*.lua", SearchOption.AllDirectories))
             //{

--- a/Benchmark/Implementations/MoonSharpImplementation.cs
+++ b/Benchmark/Implementations/MoonSharpImplementation.cs
@@ -4,7 +4,7 @@ namespace Benchmark.Implementations
 {
     public class MoonSharpImplementation : AImplementation
     {
-        private readonly Script script;
+        public readonly Script script;
 
         public MoonSharpImplementation()
         {

--- a/Benchmark/Implementations/SolarSharpImplementation.cs
+++ b/Benchmark/Implementations/SolarSharpImplementation.cs
@@ -4,7 +4,7 @@ namespace Benchmark.Implementations
 {
     public class SolarSharpImplementation : AImplementation
     {
-        private readonly Script script;
+        public readonly Script script;
 
         public SolarSharpImplementation()
         {

--- a/Benchmark/Tests/regexredux.lua-2.lua
+++ b/Benchmark/Tests/regexredux.lua-2.lua
@@ -35,7 +35,7 @@ function countmatches(variant)
 end
 
 for _, p in ipairs(variants) do
-   io.write( string.format('%s %d\n', p, countmatches(p)) )
+  string.format('%s %d\n', p, countmatches(p))
 end
 
 function partitionstring(seq)
@@ -58,5 +58,5 @@ for k, v in pairs(subst) do
   chunk_gsub(seq, k, v)
 end
 seq = table.concat(seq)
-io.write(string.format('\n%d\n%d\n%d\n', ilen, clen, #seq))
+string.format('\n%d\n%d\n%d\n', ilen, clen, #seq)
 

--- a/Profiler/Profiler.csproj
+++ b/Profiler/Profiler.csproj
@@ -1,0 +1,58 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Benchmark\Benchmark.csproj" />
+    <ProjectReference Include="..\SolarSharp.Hardwire\SolarSharp.Hardwire.csproj" />
+    <ProjectReference Include="..\SolarSharp.Interpreter\SolarSharp.Interpreter.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Tests\binarytrees.lua-2.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\empty_test.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\fannkuchredux.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\fasta.lua-3.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\knucleotide.lua-2.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\mandelbrot.lua-6.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\meteor.lua-6.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\nbody.lua-4.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\pidigits.lua-7.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\regexdna.lua-3.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\regexredux.lua-2.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\revcomp.lua-4.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Tests\spectralnorm.lua">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Profiler/Program.cs
+++ b/Profiler/Program.cs
@@ -1,0 +1,57 @@
+﻿// This is just a simple playground for profiling
+using Benchmark;
+using Benchmark.Implementations;
+using SolarSharp.Interpreter.DataTypes;
+
+var file = new LuaFile("./Tests/binarytrees.lua-2.lua");
+var itCount = 2000;
+
+var impl = new SolarSharpImplementation();
+impl.script.Globals.Set("A", (DynValue.NewCallback((ctx, arg) =>
+{
+    return DynValue.NewNumber(10);
+    //return DynValue.NewYieldReq(new DynValue[1] { DynValue.NewNumber(10) });
+    //return DynValue.NewTailCallReq(new TailCallData
+    //{
+    //    Args = new DynValue[0],
+    //    Function = DynValue.NewCallback((ctx, arg) =>
+    //    {
+    //        return DynValue.NewYieldReq(new DynValue[1] { DynValue.NewNumber(10) });
+    //    }),
+    //    Continuation = new CallbackFunction((ctx, arg) =>
+    //    {
+    //        Console.WriteLine("CONT");
+    //        return DynValue.NewNumber(20);
+    //    })
+    //});
+})));
+
+impl.Run(@"
+    local x = coroutine.create(function()
+        coroutine.yield(1)
+        coroutine.yield(""A"")
+        coroutine.yield(""B"")
+    end)
+
+    getmetatable('').__add = function(str,i)
+        print(coroutine.resume(x))
+        local _, y = coroutine.resume(x)
+        str = str .. i
+        str = str .. y
+        return str
+    end
+
+    local str = ""test""
+    print(str + ""er"")
+");
+
+//Console.WriteLine("Starting, type any key to continue");
+//Console.ReadKey();
+
+////// recommended you put your debugger here
+////for (int i = 0; i < itCount; i++)
+////{
+////    impl.Run(file.Contents);
+////}
+
+//Console.WriteLine("Done");

--- a/SolarSharp.Interpreter.Tests/EndToEnd/MetatableTests.cs
+++ b/SolarSharp.Interpreter.Tests/EndToEnd/MetatableTests.cs
@@ -309,9 +309,5 @@ end
 
             DynValue res = script.DoString(scriptCode);
         }
-
-
-
-
     }
 }

--- a/SolarSharp.Interpreter.Tests/EndToEnd/TableTests.cs
+++ b/SolarSharp.Interpreter.Tests/EndToEnd/TableTests.cs
@@ -608,38 +608,6 @@ namespace SolarSharp.Interpreter.Tests.EndToEnd
         }
 
         [Test]
-        public void PrimeTable_1()
-        {
-            string script = @"    
-			t = ${
-				ciao = 'hello'
-			}
-		";
-
-            Script s = new();
-            s.DoString(script);
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(s.Globals["t", "ciao"], Is.EqualTo("hello"));
-                Assert.That(s.Globals.Get("t").Table.OwnerScript, Is.EqualTo(null));
-            });
-        }
-
-        [Test]
-        public void PrimeTable_2()
-        {
-            string script = @"    
-			t = ${
-				ciao = function() end
-			}
-		";
-
-            Script s = new();
-            Assert.Throws<ScriptRuntimeException>(() => s.DoString(script));
-        }
-
-        [Test]
         public void Table_Length_Calculations()
         {
             Table T = new(null);

--- a/SolarSharp.Interpreter.Tests/EndToEnd/TableTests.cs
+++ b/SolarSharp.Interpreter.Tests/EndToEnd/TableTests.cs
@@ -241,7 +241,6 @@ namespace SolarSharp.Interpreter.Tests.EndToEnd
 					x[k] = v;
 				end
 
-
 				t = 
 				{
 					a = 1,
@@ -343,7 +342,7 @@ namespace SolarSharp.Interpreter.Tests.EndToEnd
             Assert.Multiple(() =>
             {
                 Assert.That(res.Type, Is.EqualTo(DataType.String));
-                Assert.That(res.String, Is.EqualTo("{ [1] = A,[2] = B,[3] = C,[\"a\"] = 1,[\"c\"] = 3,[\"b\"] = 2,[\"e\"] = 5,[\"d\"] = 4,}"));
+                Assert.That(res.String, Is.EqualTo("{ [1] = A,[2] = B,[3] = C,[\"a\"] = 1,[\"b\"] = 2,[\"c\"] = 3,[\"d\"] = 4,[\"e\"] = 5,} "));
             });
         }
 

--- a/SolarSharp.Interpreter.Tests/EndToEnd/TableTests.cs
+++ b/SolarSharp.Interpreter.Tests/EndToEnd/TableTests.cs
@@ -280,6 +280,72 @@ namespace SolarSharp.Interpreter.Tests.EndToEnd
             });
         }
 
+        [Test]
+        public void TableWithArraysNextWithChangeInCollection()
+        {
+            string script = @"
+				x = { }
+
+				function copy(k, v)
+					x[k] = v;
+				end
+
+				t = 
+				{
+                    ""A"", ""B"", ""C"",
+					a = 1,
+					b = 2,
+					c = 3,
+					d = 4,
+					e = 5
+				}
+
+				k,v = next(t, nil);
+				copy(k, v);
+				k,v = next(t, k);
+				copy(k, v);
+				k,v = next(t, k);
+				copy(k, v);
+
+				k,v = next(t, k);
+				copy(k, v);
+
+				k,v = next(t, k);
+				copy(k, v);
+				v = nil;
+
+				k,v = next(t, k);
+				copy(k, v);
+
+				k,v = next(t, k);
+				copy(k, v);
+
+				k,v = next(t, k);
+				copy(k, v);
+
+                function dump(o)
+                   if type(o) == 'table' then
+                      local s = '{ '
+                      for k,v in pairs(o) do
+                         if type(k) ~= 'number' then k = '""'..k..'""' end
+                         s = s .. '['..k..'] = ' .. dump(v) .. ','
+                      end
+                      return s .. '} '
+                   else
+                      return tostring(o)
+                   end
+                end
+
+				return dump(x)";
+
+            DynValue res = Script.RunString(script);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(res.Type, Is.EqualTo(DataType.String));
+                Assert.That(res.String, Is.EqualTo("{ [1] = A,[2] = B,[3] = C,[\"a\"] = 1,[\"c\"] = 3,[\"b\"] = 2,[\"e\"] = 5,[\"d\"] = 4,}"));
+            });
+        }
 
         [Test]
         public void TablePairsWithoutMetatable()

--- a/SolarSharp.Interpreter.Tests/EndToEnd/UserDataMethodsTests.cs
+++ b/SolarSharp.Interpreter.Tests/EndToEnd/UserDataMethodsTests.cs
@@ -198,6 +198,7 @@ namespace SolarSharp.Interpreter.Tests.EndToEnd
             public static StringBuilder ConcatS(int p1, string p2, IComparable p3, bool p4, List<object> p5, IEnumerable<object> p6,
                 StringBuilder p7, Dictionary<object, object> p8, SomeClass p9, int p10 = 1994)
             {
+                // eheh1ciao!SOMECLASS!True|asdqwezxc|asdqwezxc|123xy|asdqweXYzxc|!SOMECLASS!1912
                 p7.Append(p1);
                 p7.Append(p2);
                 p7.Append(p3);

--- a/SolarSharp.Interpreter/CoreLib/BasicModule.cs
+++ b/SolarSharp.Interpreter/CoreLib/BasicModule.cs
@@ -26,6 +26,8 @@ namespace SolarSharp.Interpreter.CoreLib
             if (args.Count < 1) throw ScriptRuntimeException.BadArgumentValueExpected(0, "type");
 
             DynValue v = args[0];
+            if (v.Type == DataType.Iterator) return DynValue.NewString(v.Iterator.Current.Type.ToLuaTypeString());
+
             return DynValue.NewString(v.Type.ToLuaTypeString());
         }
 

--- a/SolarSharp.Interpreter/CoreLib/BasicModule.cs
+++ b/SolarSharp.Interpreter/CoreLib/BasicModule.cs
@@ -26,8 +26,6 @@ namespace SolarSharp.Interpreter.CoreLib
             if (args.Count < 1) throw ScriptRuntimeException.BadArgumentValueExpected(0, "type");
 
             DynValue v = args[0];
-            if (v.Type == DataType.Iterator) return DynValue.NewString(v.Iterator.Current.Type.ToLuaTypeString());
-
             return DynValue.NewString(v.Type.ToLuaTypeString());
         }
 

--- a/SolarSharp.Interpreter/CoreLib/MetaTableModule.cs
+++ b/SolarSharp.Interpreter/CoreLib/MetaTableModule.cs
@@ -57,8 +57,8 @@ namespace SolarSharp.Interpreter.CoreLib
 
             if (meta == null)
                 return DynValue.Nil;
-            else if (meta.RawGet("__metatable") != null)
-                return meta.Get("__metatable");
+            else if (meta.Get("__metatable") is var metaTable && metaTable.IsNotNil())
+                return metaTable;
             else
                 return DynValue.NewTable(meta);
         }

--- a/SolarSharp.Interpreter/CoreLib/TableIteratorsModule.cs
+++ b/SolarSharp.Interpreter/CoreLib/TableIteratorsModule.cs
@@ -61,12 +61,7 @@ namespace SolarSharp.Interpreter.CoreLib
             DynValue table = args.AsType(0, "next", DataType.Table);
             DynValue index = args[1];
 
-            TablePair? pair = table.Table.NextKey(index);
-
-            if (pair.HasValue)
-                return DynValue.NewTuple(pair.Value.Key, pair.Value.Value);
-            else
-                throw new ScriptRuntimeException("invalid key to 'next'");
+            return table.Table.GetNextFromIt(index);
         }
 
         // __next_i (table [, index])

--- a/SolarSharp.Interpreter/DataTypes/CallbackArguments.cs
+++ b/SolarSharp.Interpreter/DataTypes/CallbackArguments.cs
@@ -184,9 +184,9 @@ namespace SolarSharp.Interpreter.DataTypes
         public string AsStringUsingMeta(ScriptExecutionContext executionContext, int argNum, string funcName)
         {
             if (this[argNum].Type == DataType.Table && this[argNum].Table.MetaTable != null &&
-                this[argNum].Table.MetaTable.RawGet("__tostring") != null)
+                this[argNum].Table.MetaTable.Get("__tostring") is var method && method.IsNotNil())
             {
-                var v = executionContext.GetScript().Call(this[argNum].Table.MetaTable.RawGet("__tostring"), this[argNum]);
+                var v = executionContext.GetScript().Call(method, this[argNum]);
 
                 if (v.Type != DataType.String)
                     throw new ScriptRuntimeException("'tostring' must return a string to '{0}'", funcName);

--- a/SolarSharp.Interpreter/DataTypes/DataType.cs
+++ b/SolarSharp.Interpreter/DataTypes/DataType.cs
@@ -124,6 +124,13 @@ namespace SolarSharp.Interpreter.DataTypes
         /// A request to coroutine.yield
         /// </summary>
         YieldRequest,
+
+        /// <summary>
+        /// Special type that is purely used for cases like next
+        /// let's us do efficient cycling through a table while still allowing
+        /// the value to be used as an index.
+        /// </summary>
+        Iterator,
     }
 
     /// <summary>

--- a/SolarSharp.Interpreter/DataTypes/DataType.cs
+++ b/SolarSharp.Interpreter/DataTypes/DataType.cs
@@ -3,6 +3,66 @@
 namespace SolarSharp.Interpreter.DataTypes
 {
     /// <summary>
+    /// Is similar to <see cref="DataType"/> but matches Lua closer
+    /// and gets rid of the unnecessary types.
+    /// </summary>
+    public enum LuaDataType
+    {
+        /// <summary>
+        /// No value
+        /// </summary>
+        None = -1,
+
+        /// <summary>
+        /// A nil/null value
+        /// </summary>
+        Nil,
+
+        /// <summary>
+        /// True/false
+        /// </summary>
+        Boolean,
+
+        /// <summary>
+        /// This is pretty much just a pointer
+        /// much cheaper than normal user data.
+        /// </summary>
+        LightUserData,
+
+        /// <summary>
+        /// Doubles only for now (lua 5.2)
+        /// </summary>
+        Number,
+
+        /// <summary>
+        /// It's a c# string which doesn't match lua's specs
+        /// but makes it easier to work with in c#
+        /// </summary>
+        String,
+
+        /// <summary>
+        /// For both associative and arrays
+        /// </summary>
+        Table,
+
+        /// <summary>
+        /// Any callable
+        /// </summary>
+        Function,
+
+        /// <summary>
+        /// Heavier user data than <see cref="LightUserData"/>
+        /// but has more functionalities
+        /// </summary>
+        UserData,
+
+        /// <summary>
+        /// A coroutine handle
+        /// </summary>
+        Thread,
+    }
+
+    /// <summary>
     /// Enumeration of possible data types in MoonSharp
     /// </summary>
     public enum DataType

--- a/SolarSharp.Interpreter/DataTypes/DataType.cs
+++ b/SolarSharp.Interpreter/DataTypes/DataType.cs
@@ -196,33 +196,21 @@ namespace SolarSharp.Interpreter.DataTypes
         /// <exception cref="ScriptRuntimeException">The DataType is not a Lua type</exception>
         public static string ToLuaTypeString(this DataType type)
         {
-            switch (type)
+            return type switch
             {
-                case DataType.Void:
-                case DataType.Nil:
-                    return "nil";
-                case DataType.Boolean:
-                    return "boolean";
-                case DataType.Number:
-                    return "number";
-                case DataType.String:
-                    return "string";
-                case DataType.Function:
-                    return "function";
-                case DataType.ClrFunction:
-                    return "function";
-                case DataType.Table:
-                    return "table";
-                case DataType.UserData:
-                    return "userdata";
-                case DataType.Thread:
-                    return "thread";
-                case DataType.Tuple:
-                case DataType.TailCallRequest:
-                case DataType.YieldRequest:
-                default:
-                    throw new ScriptRuntimeException("Unexpected LuaType {0}", type);
-            }
+                // TODO: This should take a dyn value not a type so we can properly handle this better.
+                DataType.Iterator => "iterator",
+                DataType.Void or DataType.Nil => "nil",
+                DataType.Boolean => "boolean",
+                DataType.Number => "number",
+                DataType.String => "string",
+                DataType.Function => "function",
+                DataType.ClrFunction => "function",
+                DataType.Table => "table",
+                DataType.UserData => "userdata",
+                DataType.Thread => "thread",
+                _ => throw new ScriptRuntimeException("Unexpected LuaType {0}", type),
+            };
         }
     }
 }

--- a/SolarSharp.Interpreter/DataTypes/DataType.cs
+++ b/SolarSharp.Interpreter/DataTypes/DataType.cs
@@ -124,13 +124,6 @@ namespace SolarSharp.Interpreter.DataTypes
         /// A request to coroutine.yield
         /// </summary>
         YieldRequest,
-
-        /// <summary>
-        /// Special type that is purely used for cases like next
-        /// let's us do efficient cycling through a table while still allowing
-        /// the value to be used as an index.
-        /// </summary>
-        Iterator,
     }
 
     /// <summary>
@@ -198,8 +191,6 @@ namespace SolarSharp.Interpreter.DataTypes
         {
             return type switch
             {
-                // TODO: This should take a dyn value not a type so we can properly handle this better.
-                DataType.Iterator => "iterator",
                 DataType.Void or DataType.Nil => "nil",
                 DataType.Boolean => "boolean",
                 DataType.Number => "number",

--- a/SolarSharp.Interpreter/DataTypes/DynValue.cs
+++ b/SolarSharp.Interpreter/DataTypes/DynValue.cs
@@ -76,7 +76,7 @@ namespace SolarSharp.Interpreter.DataTypes
         /// </summary>
         public YieldRequest YieldRequest { get { return m_Object as YieldRequest; } }
         /// <summary>
-        /// Gets the tail call data.
+        /// Gets the user data.
         /// </summary>
         public UserData UserData { get { return m_Object as UserData; } }
 
@@ -84,8 +84,6 @@ namespace SolarSharp.Interpreter.DataTypes
         /// Returns true if this instance is write protected.
         /// </summary>
         public bool ReadOnly { get { return m_ReadOnly; } }
-
-
 
         /// <summary>
         /// Creates a new writable value initialized to Nil.
@@ -727,7 +725,6 @@ namespace SolarSharp.Interpreter.DataTypes
             return m_Object as IScriptPrivateResource;
         }
 
-
         /// <summary>
         /// Converts a tuple to a scalar value. If it's already a scalar value, this function returns "this".
         /// </summary>
@@ -755,10 +752,11 @@ namespace SolarSharp.Interpreter.DataTypes
             m_Number = value.m_Number;
             m_Object = value.m_Object;
             m_Type = value.Type;
+            // TODO: I'm not certain this is correct, this seems very odd
+            //       hashcodes should be preservable and we should be able to just
+            //       take the dyn value's hash code.
             m_HashCode = -1;
         }
-
-
 
         /// <summary>
         /// Gets the length of a string or table value.
@@ -871,15 +869,13 @@ namespace SolarSharp.Interpreter.DataTypes
             return myObject;
         }
 
-#if HASDYNAMIC
 		/// <summary>
 		/// Converts this MoonSharp DynValue to a CLR object, marked as dynamic
 		/// </summary>
 		public dynamic ToDynamic()
 		{
-			return SolarSharp.Interpreter.Interop.Converters.ScriptToClrConversions.DynValueToObject(this);
+			return ScriptToClrConversions.DynValueToObject(this);
 		}
-#endif
 
         /// <summary>
         /// Checks the type of this value corresponds to the desired type. A propert ScriptRuntimeException is thrown

--- a/SolarSharp.Interpreter/DataTypes/DynValue.cs
+++ b/SolarSharp.Interpreter/DataTypes/DynValue.cs
@@ -231,9 +231,9 @@ namespace SolarSharp.Interpreter.DataTypes
         /// <summary>
         /// Creates a new writable value initialized to an empty table.
         /// </summary>
-        public static DynValue NewTable(Script script)
+        public static DynValue NewTable(Script script, int arraySizeHint = 0, int associativeSizeHint = 0)
         {
-            return NewTable(new Table(script));
+            return NewTable(new Table(script, arraySizeHint, associativeSizeHint));
         }
 
         /// <summary>

--- a/SolarSharp.Interpreter/DataTypes/DynValue.cs
+++ b/SolarSharp.Interpreter/DataTypes/DynValue.cs
@@ -748,6 +748,9 @@ namespace SolarSharp.Interpreter.DataTypes
         /// </summary>
         public DynValue ToScalar()
         {
+            if (Type == DataType.Iterator)
+                return Iterator.Current;
+
             if (Type != DataType.Tuple)
                 return this;
 

--- a/SolarSharp.Interpreter/DataTypes/Iterator.cs
+++ b/SolarSharp.Interpreter/DataTypes/Iterator.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace SolarSharp.Interpreter.DataTypes
+{
+    public class Iterator
+    {
+        public Iterator(IEnumerator<KeyValuePair<DynValue, DynValue>> it)
+        {
+            It = it;
+        }
+
+        public DynValue Current { get; set; }
+        public IEnumerator<KeyValuePair<DynValue, DynValue>> It { get; }
+
+        public DynValue Next()
+        {
+        repeat:
+            if (It.MoveNext()) 
+            {
+                // skip over nils
+                if (It.Current.Value == null) goto repeat;
+                Current = It.Current.Key;
+                return It.Current.Value;
+            }
+            else
+            {
+                Current = null;
+                return null;
+            }
+        }
+    }
+}

--- a/SolarSharp.Interpreter/DataTypes/LuaValue.cs
+++ b/SolarSharp.Interpreter/DataTypes/LuaValue.cs
@@ -1,0 +1,82 @@
+﻿using System.Runtime.InteropServices;
+
+namespace SolarSharp.Interpreter.DataTypes
+{
+    /// <summary>
+    /// Inspired by Lua's actual implementation of values, is a significantly more efficient
+    /// value than a <see cref="DynValue"/> since it's 1) a struct and 2) stores a lot less information
+    /// 
+    /// Note: we may have to do some unsafe stuff like; https://stackoverflow.com/a/72507955 to make *some* writes performant
+    /// but I don't think the vast majority of this will be true.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    public struct LuaValue
+    {
+        // Both none & nil don't have an explicit value here but they are zeroed out so effectively are "0"
+
+        /// <summary>
+        /// Bools are 0/1
+        /// </summary>
+        [FieldOffset(0)]
+        public bool BoolValue;
+
+        /// <summary>
+        /// Is just a "ptr" or object reference.
+        /// 
+        /// I may change this to dynamic just to allow for easier function calls.
+        /// </summary>
+        [FieldOffset(0)]
+        public object LightUserDataValue;
+
+        /// <summary>
+        /// Numbers are all doubles (since we are Lua 5.2)
+        /// </summary>
+        [FieldOffset(0)]
+        public double NumberValue;
+
+        /// <summary>
+        /// Avoid the cast to string by having a direct ref to it.
+        /// </summary>
+        [FieldOffset(0)]
+        public string StringValue;
+
+        /// <summary>
+        /// Standard lua table
+        /// </summary>
+        [FieldOffset(0)]
+        public Table TableValue;
+
+        /// <summary>
+        /// A lua function!  This doesn't cover a CLR function
+        /// (for now) since I'll probably use a different type
+        /// just for more performant calls.
+        /// </summary>
+        [FieldOffset(0)]
+        public Closure FunctionValue;
+
+        /// <summary>
+        /// User data.
+        /// </summary>
+        [FieldOffset(0)]
+        public UserData UserDataValue;
+
+        /// <summary>
+        /// A coroutine
+        /// </summary>
+        [FieldOffset(0)]
+        public Coroutine ThreadValue;
+
+        /// <summary>
+        /// The type of lua value
+        /// 
+        /// In future I'm planning on using a NaN tagged value (potentially) to get better performance
+        /// </summary>
+        [FieldOffset(8)]
+        public LuaDataType Type;
+
+        /// <summary>
+        /// Create a new nil value.
+        /// </summary>
+        public static readonly LuaValue Nil = new() { Type = LuaDataType.Nil };
+    }
+}

--- a/SolarSharp.Interpreter/DataTypes/Table.cs
+++ b/SolarSharp.Interpreter/DataTypes/Table.cs
@@ -82,7 +82,7 @@ namespace SolarSharp.Interpreter.DataTypes
         private int GetIntegralKey(double d)
         {
             int v = (int)d;
-            if (d >= 1.0 && d == v)
+            if (d >= 0.0 && d == v)
                 return v;
 
             return -1;
@@ -417,7 +417,7 @@ namespace SolarSharp.Interpreter.DataTypes
             // this only cleans up the map and doesn't touch the array
             foreach (var key in DeadKeys)
             {
-                ValueMap.Remove(key);
+                if (ValueMap[key] == null) ValueMap.Remove(key);
             }
             DeadKeys.Clear();
             // note: we could use ValueMap.remove & an iterator in new versions of C# (.netcore 3)
@@ -434,13 +434,21 @@ namespace SolarSharp.Interpreter.DataTypes
             if (v.IsNil())
             {
                 v = DynValue.NewNumber(0);
+                if (ArraySegment.Length > 0 && ArraySegment[0] != null)
+                {
+                    return DynValue.NewTuple(v, ArraySegment[0]);
+                }
             }
 
             if (v.Type == DataType.Number && GetIntegralKey(v.Number) is var n
                 && n >= 0 && n < MAX_INT_KEY_ARRAY)
             {
                 // we are looping through the array segment first
-                while (n < ArraySegment.Length - 1 && ArraySegment[n + 1] != null) n++;
+                do
+                {
+                    n++;
+                }
+                while (n < ArraySegment.Length && ArraySegment[n] == null);
                 
                 // if we are at the end
                 if (n == ArraySegment.Length)

--- a/SolarSharp.Interpreter/DataTypes/Table.cs
+++ b/SolarSharp.Interpreter/DataTypes/Table.cs
@@ -20,6 +20,11 @@ namespace SolarSharp.Interpreter.DataTypes
         private bool m_ContainsNilEntries = false;
 
         /// <summary>
+        /// The array segment of the table.
+        /// </summary>
+        private readonly List<DynValue> ArraySegment;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Table"/> class.
         /// </summary>
         /// <param name="owner">The owner script.</param>
@@ -271,10 +276,10 @@ namespace SolarSharp.Interpreter.DataTypes
             if (key == null)
                 throw ScriptRuntimeException.TableIndexIsNil();
 
-            if (key is string)
-                Set((string)key, value);
-            else if (key is int)
-                Set((int)key, value);
+            if (key is string s)
+                Set(s, value);
+            else if (key is int i)
+                Set(i, value);
             else
                 Set(DynValue.FromObject(OwnerScript, key), value);
         }
@@ -283,7 +288,7 @@ namespace SolarSharp.Interpreter.DataTypes
         /// Sets the value associated with the specified keys.
         /// Multiple keys can be used to access subtables.
         /// </summary>
-        /// <param name="key">The keys.</param>
+        /// <param name="keys">The keys.</param>
         /// <param name="value">The value.</param>
         public void Set(object[] keys, DynValue value)
         {
@@ -541,7 +546,6 @@ namespace SolarSharp.Interpreter.DataTypes
             m_CachedLength = -1;
         }
 
-
         /// <summary>
         /// Returns the next pair from a value
         /// </summary>
@@ -596,7 +600,6 @@ namespace SolarSharp.Interpreter.DataTypes
                     return linkedListNode.Value;
             }
         }
-
 
         /// <summary>
         /// Gets the length of the "array part".

--- a/SolarSharp.Interpreter/DataTypes/Table.cs
+++ b/SolarSharp.Interpreter/DataTypes/Table.cs
@@ -592,23 +592,28 @@ namespace SolarSharp.Interpreter.DataTypes
             m_MetaTable = value; }
         }
         private Table m_MetaTable;
+        
+        private IEnumerable<KeyValuePair<DynValue, DynValue>> ArrayPairs =>
+            ArraySegment
+                .Select((v, i) => new KeyValuePair<DynValue, DynValue>(DynValue.NewNumber(i), v))
+                .Where(kvp => kvp.Value != null);
 
         /// <summary>
         /// Enumerates the key/value pairs.
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<KeyValuePair<DynValue, DynValue>> Pairs => ValueMap;
+        public IEnumerable<KeyValuePair<DynValue, DynValue>> Pairs => ArrayPairs.Concat(ValueMap.Where(kvp => kvp.Value != null));
 
         /// <summary>
         /// Enumerates the keys.
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<DynValue> Keys => ValueMap.Keys;
+        public IEnumerable<DynValue> Keys => Pairs.Select(p => p.Key);
 
         /// <summary>
         /// Enumerates the values
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<DynValue> Values => ValueMap.Values;
+        public IEnumerable<DynValue> Values => Pairs.Select(p => p.Value);
     }
 }

--- a/SolarSharp.Interpreter/DataTypes/TablePair.cs
+++ b/SolarSharp.Interpreter/DataTypes/TablePair.cs
@@ -26,7 +26,6 @@
             set { if (key.IsNotNil()) Value = value; }
         }
 
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TablePair"/> struct.
         /// </summary>

--- a/SolarSharp.Interpreter/Execution/VM/ByteCode.cs
+++ b/SolarSharp.Interpreter/Execution/VM/ByteCode.cs
@@ -204,9 +204,9 @@ namespace SolarSharp.Interpreter.Execution.VM
             return AppendInstruction(new Instruction(m_CurrentSourceRef) { OpCode = OpCode.Incr, NumVal = i });
         }
 
-        public Instruction Emit_NewTable(bool shared)
+        public Instruction Emit_NewTable(int arraySizeHint, int associativeSizeHint)
         {
-            return AppendInstruction(new Instruction(m_CurrentSourceRef) { OpCode = OpCode.NewTable, NumVal = shared ? 1 : 0 });
+            return AppendInstruction(new Instruction(m_CurrentSourceRef) { OpCode = OpCode.NewTable, NumVal = arraySizeHint, NumVal2 = associativeSizeHint });
         }
 
         public Instruction Emit_IterPrep()
@@ -295,9 +295,9 @@ namespace SolarSharp.Interpreter.Execution.VM
             return AppendInstruction(new Instruction(m_CurrentSourceRef) { OpCode = OpCode.TblInitN });
         }
 
-        public Instruction Emit_TblInitI(bool lastpos)
+        public Instruction Emit_TblInitI(int idx)
         {
-            return AppendInstruction(new Instruction(m_CurrentSourceRef) { OpCode = OpCode.TblInitI, NumVal = lastpos ? 1 : 0 });
+            return AppendInstruction(new Instruction(m_CurrentSourceRef) { OpCode = OpCode.TblInitI, NumVal = idx });
         }
 
         public Instruction Emit_Index(DynValue index = null, bool isNameIndex = false, bool isExpList = false)

--- a/SolarSharp.Interpreter/Execution/VM/OpCode.cs
+++ b/SolarSharp.Interpreter/Execution/VM/OpCode.cs
@@ -56,7 +56,6 @@
         Power,      // Power of the two topmost operands on the v-stack
         CNot,       // Conditional NOT - takes second operand from the v-stack (must be bool), if true execs a NOT otherwise execs a TOBOOL
 
-
         // Type conversions and manipulations
         MkTuple,    // Creates a tuple from the topmost n values
         Scalar,     // Converts the topmost tuple to a scalar
@@ -64,7 +63,6 @@
         ToNum,      // Converts the top of the stack to a number
         ToBool,     // Converts the top of the stack to a boolean
         ExpTuple,   // Expands a tuple on the stack
-
 
         // Iterators
         IterPrep,   // Prepares an iterator for execution 

--- a/SolarSharp.Interpreter/Execution/VM/Processor/Processor_Debugger.cs
+++ b/SolarSharp.Interpreter/Execution/VM/Processor/Processor_Debugger.cs
@@ -28,7 +28,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             return meta;
         }
 
-
         internal void AttachDebugger(IDebugger debugger)
         {
             m_Debug.DebuggerAttached = debugger;
@@ -41,7 +40,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             get { return m_Debug.DebuggerEnabled; }
             set { m_Debug.DebuggerEnabled = value; }
         }
-
 
         private void ListenDebugger(Instruction instr, int instructionPtr)
         {
@@ -58,7 +56,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             {
                 isOnDifferentRef = instr.SourceCodeRef != null;
             }
-
 
             if (m_Debug.DebuggerAttached.IsPauseRequested() ||
                 (instr.SourceCodeRef != null && instr.SourceCodeRef.Breakpoint && isOnDifferentRef))
@@ -87,7 +84,6 @@ namespace SolarSharp.Interpreter.Execution.VM
                     if (instr.SourceCodeRef == null || instr.SourceCodeRef == m_Debug.LastHlRef || m_ExecutionStack.Count > m_Debug.ExStackDepthAtStep) return;
                     break;
             }
-
 
             RefreshDebugger(false, instructionPtr);
 

--- a/SolarSharp.Interpreter/Execution/VM/Processor/Processor_IExecutionContext.cs
+++ b/SolarSharp.Interpreter/Execution/VM/Processor/Processor_IExecutionContext.cs
@@ -25,16 +25,16 @@ namespace SolarSharp.Interpreter.Execution.VM
             var op1_MetaTable = GetMetatable(op1);
             if (op1_MetaTable != null)
             {
-                DynValue meta1 = op1_MetaTable.RawGet(eventName);
-                if (meta1 != null && meta1.IsNotNil())
+                DynValue meta1 = op1_MetaTable.Get(eventName);
+                if (meta1.IsNotNil())
                     return meta1;
             }
 
             var op2_MetaTable = GetMetatable(op2);
             if (op2_MetaTable != null)
             {
-                DynValue meta2 = op2_MetaTable.RawGet(eventName);
-                if (meta2 != null && meta2.IsNotNil())
+                DynValue meta2 = op2_MetaTable.Get(eventName);
+                if (meta2.IsNotNil())
                     return meta2;
             }
 
@@ -79,9 +79,9 @@ namespace SolarSharp.Interpreter.Execution.VM
             if (metatable == null)
                 return null;
 
-            var metameth = metatable.RawGet(metamethod);
+            var metameth = metatable.Get(metamethod);
 
-            if (metameth == null || metameth.IsNil())
+            if (metameth.IsNil())
                 return null;
 
             return metameth;

--- a/SolarSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/SolarSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -152,10 +152,8 @@ namespace SolarSharp.Interpreter.Execution.VM
                             instructionPtr = ExecJFor(i, instructionPtr);
                             break;
                         case OpCode.NewTable:
-                            if (i.NumVal == 0)
-                                m_ValueStack.Push(DynValue.NewTable(m_Script));
-                            else
-                                m_ValueStack.Push(DynValue.NewPrimeTable());
+                            // we pass the hints we got from the instruction args
+                            m_ValueStack.Push(DynValue.NewTable(m_Script, i.NumVal, i.NumVal2));
                             break;
                         case OpCode.IterPrep:
                             ExecIterPrep();
@@ -858,7 +856,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             }
         }
 
-
         private int ExecMul(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
@@ -1114,7 +1111,8 @@ namespace SolarSharp.Interpreter.Execution.VM
             if (tbl.Type != DataType.Table)
                 throw new InternalErrorException("Unexpected type in table ctor : {0}", tbl);
 
-            tbl.Table.InitNextArrayKeys(val, i.NumVal != 0);
+            // the instruction arg holds the index
+            tbl.Table.InitNextArrayKeys(val, i.NumVal);
         }
 
         private void ExecTblInitN()

--- a/SolarSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/SolarSharp.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -51,40 +51,40 @@ namespace SolarSharp.Interpreter.Execution.VM
                             m_ValueStack.Push(i.Value);
                             break;
                         case OpCode.Add:
-                            instructionPtr = ExecAdd(i, instructionPtr);
+                            instructionPtr = ExecAdd(instructionPtr);
                             break;
                         case OpCode.Concat:
-                            instructionPtr = ExecConcat(i, instructionPtr);
+                            instructionPtr = ExecConcat(instructionPtr);
                             break;
                         case OpCode.Neg:
-                            instructionPtr = ExecNeg(i, instructionPtr);
+                            instructionPtr = ExecNeg(instructionPtr);
                             break;
                         case OpCode.Sub:
-                            instructionPtr = ExecSub(i, instructionPtr);
+                            instructionPtr = ExecSub(instructionPtr);
                             break;
                         case OpCode.Mul:
-                            instructionPtr = ExecMul(i, instructionPtr);
+                            instructionPtr = ExecMul(instructionPtr);
                             break;
                         case OpCode.Div:
-                            instructionPtr = ExecDiv(i, instructionPtr);
+                            instructionPtr = ExecDiv(instructionPtr);
                             break;
                         case OpCode.Mod:
-                            instructionPtr = ExecMod(i, instructionPtr);
+                            instructionPtr = ExecMod(instructionPtr);
                             break;
                         case OpCode.Power:
-                            instructionPtr = ExecPower(i, instructionPtr);
+                            instructionPtr = ExecPower(instructionPtr);
                             break;
                         case OpCode.Eq:
-                            instructionPtr = ExecEq(i, instructionPtr);
+                            instructionPtr = ExecEq(instructionPtr);
                             break;
                         case OpCode.LessEq:
-                            instructionPtr = ExecLessEq(i, instructionPtr);
+                            instructionPtr = ExecLessEq(instructionPtr);
                             break;
                         case OpCode.Less:
-                            instructionPtr = ExecLess(i, instructionPtr);
+                            instructionPtr = ExecLess(instructionPtr);
                             break;
                         case OpCode.Len:
-                            instructionPtr = ExecLen(i, instructionPtr);
+                            instructionPtr = ExecLen(instructionPtr);
                             break;
                         case OpCode.Call:
                         case OpCode.ThisCall:
@@ -95,10 +95,10 @@ namespace SolarSharp.Interpreter.Execution.VM
                             m_ValueStack.Push(m_ValueStack.Pop().ToScalar());
                             break;
                         case OpCode.Not:
-                            ExecNot(i);
+                            ExecNot();
                             break;
                         case OpCode.CNot:
-                            ExecCNot(i);
+                            ExecCNot();
                             break;
                         case OpCode.JfOrPop:
                         case OpCode.JtOrPop:
@@ -153,15 +153,15 @@ namespace SolarSharp.Interpreter.Execution.VM
                             break;
                         case OpCode.NewTable:
                             if (i.NumVal == 0)
-                                m_ValueStack.Push(DynValue.NewTable(this.m_Script));
+                                m_ValueStack.Push(DynValue.NewTable(m_Script));
                             else
                                 m_ValueStack.Push(DynValue.NewPrimeTable());
                             break;
                         case OpCode.IterPrep:
-                            ExecIterPrep(i);
+                            ExecIterPrep();
                             break;
                         case OpCode.IterUpd:
-                            ExecIterUpd(i);
+                            ExecIterUpd();
                             break;
                         case OpCode.ExpTuple:
                             ExecExpTuple(i);
@@ -181,7 +181,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                             ExecStoreLcl(i);
                             break;
                         case OpCode.TblInitN:
-                            ExecTblInitN(i);
+                            ExecTblInitN();
                             break;
                         case OpCode.TblInitI:
                             ExecTblInitI(i);
@@ -210,7 +210,7 @@ namespace SolarSharp.Interpreter.Execution.VM
 
                 if (m_CanYield)
                     return yieldRequest;
-                else if (this.State == CoroutineState.Main)
+                else if (State == CoroutineState.Main)
                     throw ScriptRuntimeException.CannotYieldMain();
                 else
                     throw ScriptRuntimeException.CannotYield();
@@ -219,7 +219,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             {
                 FillDebugData(ex, instructionPtr);
 
-                if (!(ex is ScriptRuntimeException))
+                if (ex is not ScriptRuntimeException)
                 {
                     ex.Rethrow();
                     throw;
@@ -229,7 +229,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                 {
                     if (m_Debug.DebuggerAttached.SignalRuntimeException((ScriptRuntimeException)ex))
                     {
-                        if (instructionPtr >= 0 && instructionPtr < this.m_RootChunk.Code.Count)
+                        if (instructionPtr >= 0 && instructionPtr < m_RootChunk.Code.Count)
                         {
                             ListenDebugger(m_RootChunk.Code[instructionPtr], instructionPtr);
                         }
@@ -290,7 +290,7 @@ namespace SolarSharp.Interpreter.Execution.VM
 
                 if (messageHandler.Type == DataType.Function)
                 {
-                    ret = this.Call(messageHandler, args);
+                    ret = Call(messageHandler, args);
                 }
                 else if (messageHandler.Type == DataType.ClrFunction)
                 {
@@ -375,8 +375,8 @@ namespace SolarSharp.Interpreter.Execution.VM
 
         private void ExecClosure(Instruction i)
         {
-            Closure c = new(this.m_Script, i.NumVal, i.SymbolList,
-                i.SymbolList.Select(s => this.GetUpvalueSymbol(s)).ToList());
+            Closure c = new(m_Script, i.NumVal, i.SymbolList,
+                i.SymbolList.Select(s => GetUpvalueSymbol(s)).ToList());
 
             m_ValueStack.Push(DynValue.NewClosure(c));
         }
@@ -410,7 +410,7 @@ namespace SolarSharp.Interpreter.Execution.VM
         }
 
 
-        private void ExecIterUpd(Instruction i)
+        private void ExecIterUpd()
         {
             DynValue v = m_ValueStack.Peek(0);
             DynValue t = m_ValueStack.Peek(1);
@@ -433,7 +433,7 @@ namespace SolarSharp.Interpreter.Execution.VM
 
         }
 
-        private void ExecIterPrep(Instruction i)
+        private void ExecIterPrep()
         {
             DynValue v = m_ValueStack.Pop();
 
@@ -452,11 +452,11 @@ namespace SolarSharp.Interpreter.Execution.VM
 
             if (f.Type != DataType.Function && f.Type != DataType.ClrFunction)
             {
-                DynValue meta = this.GetMetamethod(f, "__iterator");
+                DynValue meta = GetMetamethod(f, "__iterator");
 
                 if (meta != null && !meta.IsNil())
                 {
-                    v = meta.Type != DataType.Tuple ? this.GetScript().Call(meta, f, s, var) : meta;
+                    v = meta.Type != DataType.Tuple ? GetScript().Call(meta, f, s, var) : meta;
 
                     f = v.Tuple.Length >= 1 ? v.Tuple[0] : DynValue.Nil;
                     s = v.Tuple.Length >= 2 ? v.Tuple[1] : DynValue.Nil;
@@ -467,7 +467,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                 }
                 else if (f.Type == DataType.Table)
                 {
-                    DynValue callmeta = this.GetMetamethod(f, "__call");
+                    DynValue callmeta = GetMetamethod(f, "__call");
 
                     if (callmeta == null || callmeta.IsNil())
                     {
@@ -512,7 +512,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             top.AssignNumber(top.Number + btm.Number);
         }
 
-        private void ExecCNot(Instruction i)
+        private void ExecCNot()
         {
             DynValue v = m_ValueStack.Pop().ToScalar();
             DynValue not = m_ValueStack.Pop().ToScalar();
@@ -526,7 +526,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                 m_ValueStack.Push(DynValue.NewBoolean(v.CastToBool()));
         }
 
-        private void ExecNot(Instruction i)
+        private void ExecNot()
         {
             DynValue v = m_ValueStack.Pop().ToScalar();
             m_ValueStack.Push(DynValue.NewBoolean(!(v.CastToBool())));
@@ -548,15 +548,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             if (csi.BasePointer >= 0)
                 m_ValueStack.CropAtCount(csi.BasePointer);
             return csi;
-        }
-
-        private int PopExecStackAndCheckVStack(int vstackguard)
-        {
-            var xs = m_ExecutionStack.Pop();
-            if (vstackguard != xs.BasePointer)
-                throw new InternalErrorException("StackGuard violation");
-
-            return xs.ReturnAddress;
         }
 
         private IList<DynValue> CreateArgsListForFunctionCall(int numargs, int offsFromTop)
@@ -594,7 +585,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             {
                 if (i >= argsList.Count)
                 {
-                    this.AssignLocal(I.SymbolList[i], DynValue.NewNil());
+                    AssignLocal(I.SymbolList[i], DynValue.NewNil());
                 }
                 else if ((i == I.SymbolList.Length - 1) && (I.SymbolList[i].i_Name == WellKnownSymbols.VARARGS))
                 {
@@ -606,11 +597,11 @@ namespace SolarSharp.Interpreter.Execution.VM
                         varargs[ii] = argsList[i].ToScalar().CloneAsWritable();
                     }
 
-                    this.AssignLocal(I.SymbolList[^1], DynValue.NewTuple(Internal_AdjustTuple(varargs)));
+                    AssignLocal(I.SymbolList[^1], DynValue.NewTuple(Internal_AdjustTuple(varargs)));
                 }
                 else
                 {
-                    this.AssignLocal(I.SymbolList[i], argsList[i].ToScalar().CloneAsWritable());
+                    AssignLocal(I.SymbolList[i], argsList[i].ToScalar().CloneAsWritable());
                 }
             }
         }
@@ -623,13 +614,13 @@ namespace SolarSharp.Interpreter.Execution.VM
 
             // if TCO threshold reached
             // TODO: Remove this, I doubt it helps with performance since we already have support for tail call...
-            if ((m_ExecutionStack.Count > this.m_Script.Options.TailCallOptimizationThreshold && m_ExecutionStack.Count > 1)
-                || (m_ValueStack.Count > this.m_Script.Options.TailCallOptimizationThreshold && m_ValueStack.Count > 1))
+            if ((m_ExecutionStack.Count > m_Script.Options.TailCallOptimizationThreshold && m_ExecutionStack.Count > 1)
+                || (m_ValueStack.Count > m_Script.Options.TailCallOptimizationThreshold && m_ValueStack.Count > 1))
             {
                 // and the "will-be" return address is valid (we don't want to crash here)
-                if (instructionPtr >= 0 && instructionPtr < this.m_RootChunk.Code.Count)
+                if (instructionPtr >= 0 && instructionPtr < m_RootChunk.Code.Count)
                 {
-                    Instruction I = this.m_RootChunk.Code[instructionPtr];
+                    Instruction I = m_RootChunk.Code[instructionPtr];
 
                     // and we are followed *exactly* by a RET 1
                     if (I.OpCode == OpCode.Ret && I.NumVal == 1)
@@ -640,7 +631,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                         if (csi.ClrFunction == null && csi.Continuation == null && csi.ErrorHandler == null
                             && csi.ErrorHandlerBeforeUnwind == null && continuation == null && unwindHandler == null && handler == null)
                         {
-                            instructionPtr = PerformTCO(instructionPtr, argsCount);
+                            instructionPtr = PerformTCO(argsCount);
                             flags |= CallStackItemFlags.TailCall;
                         }
                     }
@@ -676,7 +667,7 @@ namespace SolarSharp.Interpreter.Execution.VM
 
                 m_ExecutionStack.Pop();
 
-                return Internal_CheckForTailRequests(null, instructionPtr);
+                return Internal_CheckForTailRequests(instructionPtr);
             }
             else if (fn.Type == DataType.Function)
             {
@@ -716,7 +707,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             throw ScriptRuntimeException.AttemptToCallNonFunc(fn.Type, debugText);
         }
 
-        private int PerformTCO(int instructionPtr, int argsCount)
+        private int PerformTCO(int argsCount)
         {
             DynValue[] args = new DynValue[argsCount + 1];
 
@@ -757,7 +748,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                 var argscnt = (int)(m_ValueStack.Pop().Number);
                 m_ValueStack.RemoveLast(argscnt + 1);
                 m_ValueStack.Push(retval);
-                retpoint = Internal_CheckForTailRequests(i, retpoint);
+                retpoint = Internal_CheckForTailRequests(retpoint);
             }
             else
             {
@@ -771,7 +762,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             return retpoint;
         }
 
-        private int Internal_CheckForTailRequests(Instruction i, int instructionPtr)
+        private int Internal_CheckForTailRequests(int instructionPtr)
         {
             DynValue tail = m_ValueStack.Peek(0);
 
@@ -825,7 +816,7 @@ namespace SolarSharp.Interpreter.Execution.VM
         }
 
 
-        private int ExecAdd(Instruction i, int instructionPtr)
+        private int ExecAdd(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -846,7 +837,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             }
         }
 
-        private int ExecSub(Instruction i, int instructionPtr)
+        private int ExecSub(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -868,7 +859,7 @@ namespace SolarSharp.Interpreter.Execution.VM
         }
 
 
-        private int ExecMul(Instruction i, int instructionPtr)
+        private int ExecMul(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -889,7 +880,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             }
         }
 
-        private int ExecMod(Instruction i, int instructionPtr)
+        private int ExecMod(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -912,7 +903,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             }
         }
 
-        private int ExecDiv(Instruction i, int instructionPtr)
+        private int ExecDiv(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -932,7 +923,8 @@ namespace SolarSharp.Interpreter.Execution.VM
                 else throw ScriptRuntimeException.ArithmeticOnNonNumber(l, r);
             }
         }
-        private int ExecPower(Instruction i, int instructionPtr)
+
+        private int ExecPower(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -954,7 +946,7 @@ namespace SolarSharp.Interpreter.Execution.VM
 
         }
 
-        private int ExecNeg(Instruction i, int instructionPtr)
+        private int ExecNeg(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             double? rn = r.CastToNumber();
@@ -972,8 +964,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             }
         }
 
-
-        private int ExecEq(Instruction i, int instructionPtr)
+        private int ExecEq(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -1015,7 +1006,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             return instructionPtr;
         }
 
-        private int ExecLess(Instruction i, int instructionPtr)
+        private int ExecLess(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -1040,8 +1031,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             return instructionPtr;
         }
 
-
-        private int ExecLessEq(Instruction i, int instructionPtr)
+        private int ExecLessEq(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -1075,7 +1065,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             return instructionPtr;
         }
 
-        private int ExecLen(Instruction i, int instructionPtr)
+        private int ExecLen(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
 
@@ -1094,7 +1084,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             return instructionPtr;
         }
 
-        private int ExecConcat(Instruction i, int instructionPtr)
+        private int ExecConcat(int instructionPtr)
         {
             DynValue r = m_ValueStack.Pop().ToScalar();
             DynValue l = m_ValueStack.Pop().ToScalar();
@@ -1127,7 +1117,7 @@ namespace SolarSharp.Interpreter.Execution.VM
             tbl.Table.InitNextArrayKeys(val, i.NumVal != 0);
         }
 
-        private void ExecTblInitN(Instruction i)
+        private void ExecTblInitN()
         {
             // stack: tbl - key - val
             DynValue val = m_ValueStack.Pop();
@@ -1182,7 +1172,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                 {
                     UserData ud = obj.UserData;
 
-                    if (!ud.Descriptor.SetIndex(this.GetScript(), ud.Object, originalIdx, value, isNameIndex))
+                    if (!ud.Descriptor.SetIndex(GetScript(), ud.Object, originalIdx, value, isNameIndex))
                     {
                         throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
                     }
@@ -1259,7 +1249,7 @@ namespace SolarSharp.Interpreter.Execution.VM
                 {
                     UserData ud = obj.UserData;
 
-                    var v = ud.Descriptor.Index(this.GetScript(), ud.Object, originalIdx, isNameIndex) ?? throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
+                    var v = ud.Descriptor.Index(GetScript(), ud.Object, originalIdx, isNameIndex) ?? throw ScriptRuntimeException.UserDataMissingField(ud.Descriptor.Name, idx.String);
                     m_ValueStack.Push(v.AsReadOnly());
                     return instructionPtr;
                 }

--- a/SolarSharp.Interpreter/Execution/VM/Processor/Processor_Scope.cs
+++ b/SolarSharp.Interpreter/Execution/VM/Processor/Processor_Scope.cs
@@ -19,7 +19,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             }
         }
 
-
         public DynValue GetGenericSymbol(SymbolRef symref)
         {
             return symref.i_Type switch
@@ -47,7 +46,6 @@ namespace SolarSharp.Interpreter.Execution.VM
 
             dynValue.Table.Set(name, value ?? DynValue.Nil);
         }
-
 
         public void AssignGenericSymbol(SymbolRef symref, DynValue value)
         {
@@ -102,7 +100,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             return stackframe;
         }
 
-
         public SymbolRef FindSymbolByName(string name)
         {
             if (m_ExecutionStack.Count > 0)
@@ -144,6 +141,5 @@ namespace SolarSharp.Interpreter.Execution.VM
                 return SymbolRef.DefaultEnv;
             }
         }
-
     }
 }

--- a/SolarSharp.Interpreter/Execution/VM/Processor/Processor_UtilityFunctions.cs
+++ b/SolarSharp.Interpreter/Execution/VM/Processor/Processor_UtilityFunctions.cs
@@ -43,8 +43,6 @@ namespace SolarSharp.Interpreter.Execution.VM
             }
         }
 
-
-
         private int Internal_InvokeUnaryMetaMethod(DynValue op1, string eventName, int instructionPtr)
         {
             DynValue m = null;
@@ -97,52 +95,5 @@ namespace SolarSharp.Interpreter.Execution.VM
                 return -1;
             }
         }
-
-        private DynValue[] StackTopToArray(int items, bool pop)
-        {
-            DynValue[] values = new DynValue[items];
-
-            if (pop)
-            {
-                for (int i = 0; i < items; i++)
-                {
-                    values[i] = m_ValueStack.Pop();
-                }
-            }
-            else
-            {
-                for (int i = 0; i < items; i++)
-                {
-                    values[i] = m_ValueStack.Storage[m_ValueStack.Count - 1 - i];
-                }
-            }
-
-            return values;
-        }
-
-        private DynValue[] StackTopToArrayReverse(int items, bool pop)
-        {
-            DynValue[] values = new DynValue[items];
-
-            if (pop)
-            {
-                for (int i = 0; i < items; i++)
-                {
-                    values[items - 1 - i] = m_ValueStack.Pop();
-                }
-            }
-            else
-            {
-                for (int i = 0; i < items; i++)
-                {
-                    values[items - 1 - i] = m_ValueStack.Storage[m_ValueStack.Count - 1 - i];
-                }
-            }
-
-            return values;
-        }
-
-
-
     }
 }

--- a/SolarSharp.Interpreter/Execution/VM/Processor/Processor_UtilityFunctions.cs
+++ b/SolarSharp.Interpreter/Execution/VM/Processor/Processor_UtilityFunctions.cs
@@ -58,8 +58,8 @@ namespace SolarSharp.Interpreter.Execution.VM
 
                 if (op1_MetaTable != null)
                 {
-                    DynValue meta1 = op1_MetaTable.RawGet(eventName);
-                    if (meta1 != null && meta1.IsNotNil())
+                    DynValue meta1 = op1_MetaTable.Get(eventName);
+                    if (meta1.IsNotNil())
                         m = meta1;
                 }
             }

--- a/SolarSharp.Interpreter/Interop/Converters/ScriptToClrConversions.cs
+++ b/SolarSharp.Interpreter/Interop/Converters/ScriptToClrConversions.cs
@@ -76,7 +76,6 @@ namespace SolarSharp.Interpreter.Interop.Converters
             }
         }
 
-
         /// <summary>
         /// Converts a DynValue to a CLR object of a specific type
         /// </summary>

--- a/SolarSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/OverloadedMethodMemberDescriptor.cs
+++ b/SolarSharp.Interpreter/Interop/StandardDescriptors/ReflectionMemberDescriptors/OverloadedMethodMemberDescriptor.cs
@@ -294,7 +294,6 @@ namespace SolarSharp.Interpreter.Interop.StandardDescriptors.ReflectionMemberDes
             return true;
         }
 
-
         /// <summary>
         /// Calculates the score for the overload.
         /// </summary>
@@ -309,7 +308,6 @@ namespace SolarSharp.Interpreter.Interop.StandardDescriptors.ReflectionMemberDes
             int argsBase = args.IsMethodCall ? 1 : 0;
             int argsCnt = argsBase;
             bool varArgsUsed = false;
-
 
             for (int i = 0; i < method.Parameters.Length; i++)
             {
@@ -414,8 +412,6 @@ namespace SolarSharp.Interpreter.Interop.StandardDescriptors.ReflectionMemberDes
             return score;
         }
 
-
-
         /// <summary>
         /// Gets a callback function as a delegate
         /// </summary>
@@ -426,7 +422,6 @@ namespace SolarSharp.Interpreter.Interop.StandardDescriptors.ReflectionMemberDes
         {
             return (context, args) => PerformOverloadedCall(script, obj, context, args);
         }
-
 
         void IOptimizableDescriptor.Optimize()
         {

--- a/SolarSharp.Interpreter/Loaders/ScriptLoaderBase.cs
+++ b/SolarSharp.Interpreter/Loaders/ScriptLoaderBase.cs
@@ -67,9 +67,9 @@ namespace SolarSharp.Interpreter.Loaders
         {
             if (!IgnoreLuaPathGlobal)
             {
-                DynValue s = globalContext.RawGet("LUA_PATH");
+                DynValue s = globalContext.Get("LUA_PATH");
 
-                if (s != null && s.Type == DataType.String)
+                if (s.IsNotNil() && s.Type == DataType.String)
                     return ResolveModuleName(modname, UnpackStringPaths(s.String));
             }
 

--- a/SolarSharp.Interpreter/Modules/ModuleRegister.cs
+++ b/SolarSharp.Interpreter/Modules/ModuleRegister.cs
@@ -193,18 +193,16 @@ namespace SolarSharp.Interpreter.Modules
                     gtable.Set(attr.Namespace, DynValue.NewTable(table));
                 }
 
-
                 DynValue package = gtable.Get("package");
 
-                if (package.IsNotNil() || package.Type != DataType.Table)
+                if (package.IsNil() || package.Type != DataType.Table)
                 {
                     gtable.Set("package", package = DynValue.NewTable(gtable.OwnerScript));
                 }
 
-
                 DynValue loaded = package.Table.Get("loaded");
 
-                if (loaded.IsNotNil() || loaded.Type != DataType.Table)
+                if (loaded.IsNil() || loaded.Type != DataType.Table)
                 {
                     package.Table.Set("loaded", loaded = DynValue.NewTable(gtable.OwnerScript));
                 }

--- a/SolarSharp.Interpreter/Modules/ModuleRegister.cs
+++ b/SolarSharp.Interpreter/Modules/ModuleRegister.cs
@@ -194,17 +194,17 @@ namespace SolarSharp.Interpreter.Modules
                 }
 
 
-                DynValue package = gtable.RawGet("package");
+                DynValue package = gtable.Get("package");
 
-                if (package == null || package.Type != DataType.Table)
+                if (package.IsNotNil() || package.Type != DataType.Table)
                 {
                     gtable.Set("package", package = DynValue.NewTable(gtable.OwnerScript));
                 }
 
 
-                DynValue loaded = package.Table.RawGet("loaded");
+                DynValue loaded = package.Table.Get("loaded");
 
-                if (loaded == null || loaded.Type != DataType.Table)
+                if (loaded.IsNotNil() || loaded.Type != DataType.Table)
                 {
                     package.Table.Set("loaded", loaded = DynValue.NewTable(gtable.OwnerScript));
                 }

--- a/SolarSharp.Interpreter/REPL/ReplInterpreterScriptLoader.cs
+++ b/SolarSharp.Interpreter/REPL/ReplInterpreterScriptLoader.cs
@@ -54,9 +54,9 @@ namespace SolarSharp.Interpreter.REPL
         /// <returns></returns>
         public override string ResolveModuleName(string modname, Table globalContext)
         {
-            DynValue s = globalContext.RawGet("LUA_PATH");
+            DynValue s = globalContext.Get("LUA_PATH");
 
-            if (s != null && s.Type == DataType.String)
+            if (s.IsNotNil() && s.Type == DataType.String)
                 return ResolveModuleName(modname, UnpackStringPaths(s.String));
 
             else

--- a/SolarSharp.Interpreter/Serialization/Json/JsonTableConverter.cs
+++ b/SolarSharp.Interpreter/Serialization/Json/JsonTableConverter.cs
@@ -38,7 +38,7 @@ namespace SolarSharp.Interpreter.Serialization.Json
             if (table.Length == 0)
             {
                 sb.Append("{");
-                foreach (TablePair pair in table.Pairs)
+                foreach (var pair in table.Pairs)
                 {
                     if (pair.Key.Type == DataType.String && IsValueJsonCompatible(pair.Value))
                     {

--- a/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
+++ b/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
@@ -31,11 +31,11 @@ namespace SolarSharp.Interpreter.Serialization
 
             if (!table.Values.Any())
             {
-                sb.Append("{ }");
+                sb.Append("${ }");
                 return sb.ToString();
             }
 
-            sb.AppendLine("{");
+            sb.AppendLine("${");
 
             foreach (var kvp in table.Pairs)
             {

--- a/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
+++ b/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
@@ -16,7 +16,6 @@ namespace SolarSharp.Interpreter.Serialization
             "and", "break", "do", "else", "elseif", "end", "false", "for", "function", "goto", "if", "in", "local", "nil", "not", "or", "repeat", "return", "then", "true", "until", "while"
         };
 
-
         public static string Serialize(this Table table, bool prefixReturn = false, int tabs = 0)
         {
             if (table.OwnerScript != null)
@@ -38,16 +37,16 @@ namespace SolarSharp.Interpreter.Serialization
 
             sb.AppendLine("${");
 
-            foreach (TablePair tp in table.Pairs)
+            foreach (var kvp in table.Pairs)
             {
                 sb.Append(tabstr);
 
                 string key =
-                    IsStringIdentifierValid(tp.Key) ?
-                    tp.Key.String : "[" + tp.Key.SerializeValue(tabs + 1) + "]";
+                    IsStringIdentifierValid(kvp.Key) ?
+                    kvp.Key.String : "[" + kvp.Key.SerializeValue(tabs + 1) + "]";
 
                 sb.AppendFormat("\t{0} = {1},\n",
-                    key, tp.Value.SerializeValue(tabs + 1));
+                    key, kvp.Value.SerializeValue(tabs + 1));
             }
 
             sb.Append(tabstr);
@@ -88,6 +87,8 @@ namespace SolarSharp.Interpreter.Serialization
                 return "nil";
             else if (dynValue.Type == DataType.Tuple)
                 return dynValue.Tuple.Any() ? dynValue.Tuple[0].SerializeValue(tabs) : "nil";
+            else if (dynValue.Type == DataType.Iterator)
+                return dynValue.Iterator.Current.SerializeValue(tabs);
             else if (dynValue.Type == DataType.Number)
                 return dynValue.Number.ToString("r");
             else if (dynValue.Type == DataType.Boolean)
@@ -114,6 +115,5 @@ namespace SolarSharp.Interpreter.Serialization
             s = s.Replace("\'", @"\'");
             return "\"" + s + "\"";
         }
-
     }
 }

--- a/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
+++ b/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
@@ -31,11 +31,11 @@ namespace SolarSharp.Interpreter.Serialization
 
             if (!table.Values.Any())
             {
-                sb.Append("${ }");
+                sb.Append("{ }");
                 return sb.ToString();
             }
 
-            sb.AppendLine("${");
+            sb.AppendLine("{");
 
             foreach (var kvp in table.Pairs)
             {

--- a/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
+++ b/SolarSharp.Interpreter/Serialization/SerializationExtensions.cs
@@ -87,8 +87,6 @@ namespace SolarSharp.Interpreter.Serialization
                 return "nil";
             else if (dynValue.Type == DataType.Tuple)
                 return dynValue.Tuple.Any() ? dynValue.Tuple[0].SerializeValue(tabs) : "nil";
-            else if (dynValue.Type == DataType.Iterator)
-                return dynValue.Iterator.Current.SerializeValue(tabs);
             else if (dynValue.Type == DataType.Number)
                 return dynValue.Number.ToString("r");
             else if (dynValue.Type == DataType.Boolean)

--- a/SolarSharp.Interpreter/Tree/Expression_.cs
+++ b/SolarSharp.Interpreter/Tree/Expression_.cs
@@ -148,8 +148,7 @@ namespace SolarSharp.Interpreter.Tree
                 case TokenType.VarArgs:
                     return new SymbolRefExpression(t, lcontext);
                 case TokenType.Brk_Open_Curly:
-                case TokenType.Brk_Open_Curly_Shared:
-                    return new TableConstructor(lcontext, t.Type == TokenType.Brk_Open_Curly_Shared);
+                    return new TableConstructor(lcontext);
                 case TokenType.Function:
                     lcontext.Lexer.Next();
                     return new FunctionDefinitionExpression(lcontext, false, false);
@@ -209,7 +208,6 @@ namespace SolarSharp.Interpreter.Tree
                     case TokenType.String:
                     case TokenType.String_Long:
                     case TokenType.Brk_Open_Curly:
-                    case TokenType.Brk_Open_Curly_Shared:
                         e = new FunctionCallExpression(lcontext, e, thisCallName);
                         break;
                     default:

--- a/SolarSharp.Interpreter/Tree/Expressions/FunctionCallExpression.cs
+++ b/SolarSharp.Interpreter/Tree/Expressions/FunctionCallExpression.cs
@@ -55,11 +55,10 @@ namespace SolarSharp.Interpreter.Tree.Expressions
                     }
                     break;
                 case TokenType.Brk_Open_Curly:
-                case TokenType.Brk_Open_Curly_Shared:
                     {
                         m_Arguments = new List<Expression>
                         {
-                            new TableConstructor(lcontext, lcontext.Lexer.Current.Type == TokenType.Brk_Open_Curly_Shared)
+                            new TableConstructor(lcontext)
                         };
                         SourceRef = callToken.GetSourceRefUpTo(lcontext.Lexer.Current);
                     }

--- a/SolarSharp.Interpreter/Tree/Lexer/Lexer.cs
+++ b/SolarSharp.Interpreter/Tree/Lexer/Lexer.cs
@@ -204,8 +204,6 @@ namespace SolarSharp.Interpreter.Tree.Lexer
                     return CreateSingleCharToken(TokenType.Op_Mod, fromLine, fromCol);
                 case '^':
                     return CreateSingleCharToken(TokenType.Op_Pwr, fromLine, fromCol);
-                case '$':
-                    return PotentiallyDoubleCharOperator('{', TokenType.Op_Dollar, TokenType.Brk_Open_Curly_Shared, fromLine, fromCol);
                 case '#':
                     if (m_Cursor == 0 && m_Code.Length > 1 && m_Code[1] == '!')
                         return ReadHashBang(fromLine, fromCol);

--- a/SolarSharp.Interpreter/Tree/Lexer/TokenType.cs
+++ b/SolarSharp.Interpreter/Tree/Lexer/TokenType.cs
@@ -65,7 +65,6 @@
         SemiColon,
         Invalid,
 
-        Brk_Open_Curly_Shared,
         Op_Dollar,
     }
 

--- a/SolarSharp.sln
+++ b/SolarSharp.sln
@@ -17,7 +17,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmark", "Benchmark\Benchmark.csproj", "{E857EA60-CCA3-4942-8F6E-0492EBE6DEFD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmark", "Benchmark\Benchmark.csproj", "{E857EA60-CCA3-4942-8F6E-0492EBE6DEFD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Profiler", "Profiler\Profiler.csproj", "{C809F605-9C69-43CD-9738-25A87ADD9F36}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -111,6 +113,22 @@ Global
 		{E857EA60-CCA3-4942-8F6E-0492EBE6DEFD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E857EA60-CCA3-4942-8F6E-0492EBE6DEFD}.Release|x86.ActiveCfg = Release|Any CPU
 		{E857EA60-CCA3-4942-8F6E-0492EBE6DEFD}.Release|x86.Build.0 = Release|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Debug|x86.Build.0 = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Dev|Any CPU.ActiveCfg = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Dev|Any CPU.Build.0 = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Dev|x86.ActiveCfg = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Dev|x86.Build.0 = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Devp4|Any CPU.ActiveCfg = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Devp4|Any CPU.Build.0 = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Devp4|x86.ActiveCfg = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Devp4|x86.Build.0 = Debug|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Release|x86.ActiveCfg = Release|Any CPU
+		{C809F605-9C69-43CD-9738-25A87ADD9F36}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Table now consists of a contiguous memory
  structure (List) for it's array segment
  rather than using a linked list.  It also
  now longer has the string map.
- OpCode NewTable now takes 2 ints that are
  hints for the size of the table's segments
- OpCode TblInitI which initializes the integer
  indexes now takes in an argument which is the
  index of the set operation.  This does technically
  mean that we can optimize some operations like
  [1] = 2, [3] = 4, ... where other lua compilers can't
  but for now we won't.
Finished table reimplementation with a few interesting sections;
1. Faster iterators, this is almost certain to change because
   I hate having to handle "iterators" everywhere and I know I've missed many spots
The way this works is just by having the iterator by an actual object that is used
first it starts off just being a standard integer (easy enough to iterate with) then
it uses an actual c# iterator object.  It just can however cast directly to an int/string/whatever

I will probably remove this in the long run though since I'm intending on having a custom dictionary
implementation that will more closely match Lua's.  The iterator type is required to avoid O(N)
for each next() in a dictionary and works well enough for strings/ints I believe.

In the long run since iterators already exist I may just encourage using that for performance over next()?

2. Uses actual arrays though the impl right now is pretty poor since it just chucks every int < 16 mil
   into array segment.